### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://dl.bintray.com/drummer-aidan/maven' }
+        maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
MD-dialog 库的url已经改为 https://jitpack.io